### PR TITLE
Compose compiler reports and optimisations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,19 @@ allprojects {
     version = "0.3.4"
 
     tasks.withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions {
+            jvmTarget = "11"
+
+            if (project.findProperty("enableComposeCompilerReports") == "true") {
+                val destinationDir = project.buildDir.absolutePath + "/compose_metrics"
+                freeCompilerArgs += listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$destinationDir",
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$destinationDir"
+                )
+            }
+        }
     }
 
     kotlinter {

--- a/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
  */
 @Composable
 internal expect fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 )

--- a/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/RouteWithArguments.kt
+++ b/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/RouteWithArguments.kt
@@ -1,9 +1,12 @@
 package io.github.lukwol.screens.navigation
 
+import androidx.compose.runtime.Immutable
+
 /**
  * A pair of [ScreenRoute] and [ScreenArguments].
  */
-internal data class ScreenRouteWithArguments(
+@Immutable
+internal data class RouteWithArguments(
     val route: ScreenRoute,
     val arguments: ScreenArguments? = null
 )

--- a/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/ScreensController.kt
+++ b/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/ScreensController.kt
@@ -36,12 +36,12 @@ interface ScreensController {
  * Actual implementation of the [ScreensController]
  */
 internal class ScreensControllerImpl(startRoute: ScreenRoute) : ScreensController {
-    internal val routesState = mutableStateListOf(ScreenRouteWithArguments(startRoute))
+    internal val routesState = mutableStateListOf(RouteWithArguments(startRoute))
 
-    override val routes get() = routesState.map(ScreenRouteWithArguments::route)
+    override val routes get() = routesState.map(RouteWithArguments::route)
 
     override fun push(route: ScreenRoute, arguments: ScreenArguments?) {
-        routesState += ScreenRouteWithArguments(route, arguments)
+        routesState += RouteWithArguments(route, arguments)
     }
 
     /**

--- a/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/ScreensNavigation.kt
+++ b/screens-navigation/src/commonMain/kotlin/io/github/lukwol/screens/navigation/ScreensNavigation.kt
@@ -2,7 +2,6 @@ package io.github.lukwol.screens.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 
 /**

--- a/screens-navigation/src/iosMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/iosMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/iosSimulatorArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/iosSimulatorArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/jsMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/jsMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/jvmMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/jvmMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -5,9 +5,9 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = when {
     animated -> Crossfade(
         targetState = route,

--- a/screens-navigation/src/linuxX64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/linuxX64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/macosArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/macosArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/macosX64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/macosX64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/mingwX64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/mingwX64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/tvosMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/tvosMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/tvosSimulatorArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/tvosSimulatorArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/watchosMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/watchosMain/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/screens-navigation/src/watchosSimulatorArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
+++ b/screens-navigation/src/watchosSimulatorArm64Main/kotlin/io/github/lukwol/screens/navigation/ChangeScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal actual fun ChangeScreen(
-    route: ScreenRouteWithArguments,
+    route: RouteWithArguments,
     animated: Boolean,
-    content: @Composable (ScreenRouteWithArguments) -> Unit
+    content: @Composable (RouteWithArguments) -> Unit
 ) = content(route)

--- a/windows-navigation/src/jvmMain/kotlin/io/github/lukwol/windows/navigation/RouteWithArguments.kt
+++ b/windows-navigation/src/jvmMain/kotlin/io/github/lukwol/windows/navigation/RouteWithArguments.kt
@@ -1,9 +1,12 @@
 package io.github.lukwol.windows.navigation
 
+import androidx.compose.runtime.Immutable
+
 /**
  * A pair of [WindowRoute] and [WindowArguments].
  */
-internal data class WindowRouteWithArguments(
+@Immutable
+internal data class RouteWithArguments(
     val route: WindowRoute,
     val arguments: WindowArguments? = null
 )

--- a/windows-navigation/src/jvmMain/kotlin/io/github/lukwol/windows/navigation/WindowsController.kt
+++ b/windows-navigation/src/jvmMain/kotlin/io/github/lukwol/windows/navigation/WindowsController.kt
@@ -36,9 +36,9 @@ interface WindowsController {
  * Actual implementation of the [WindowsController]
  */
 class WindowsControllerImpl(startRoute: WindowRoute) : WindowsController {
-    internal val routesState = mutableStateListOf(WindowRouteWithArguments(startRoute))
+    internal val routesState = mutableStateListOf(RouteWithArguments(startRoute))
 
-    override val routes get() = routesState.map(WindowRouteWithArguments::route).toSet()
+    override val routes get() = routesState.map(RouteWithArguments::route).toSet()
 
     /**
      * Opens new window for the [WindowRoute] and adds it to the [routes] stack.
@@ -53,7 +53,7 @@ class WindowsControllerImpl(startRoute: WindowRoute) : WindowsController {
         if (route in routes) {
             throw IllegalArgumentException("Window for $route is already opened")
         } else {
-            routesState += WindowRouteWithArguments(route, arguments)
+            routesState += RouteWithArguments(route, arguments)
         }
     }
 


### PR DESCRIPTION
Run `./gradlew compileKotlinJvm -PenableComposeCompilerReports=true --rerun-tasks` in order to refresh Compose Compiler metrics and raports.
Renamed `ScreenRouteWithArguments` and `WindowRouteWithArguments` to `RouteWithArguments` and annotate as `Immutable`.